### PR TITLE
Add Fisherman registration and authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,14 +35,18 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.module</groupId>
-			<artifactId>jackson-module-kotlin</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.security</groupId>
+                        <artifactId>spring-security-crypto</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>com.fasterxml.jackson.module</groupId>
+                        <artifactId>jackson-module-kotlin</artifactId>
+                </dependency>
 		<dependency>
 			<groupId>org.flywaydb</groupId>
 			<artifactId>flyway-core</artifactId>

--- a/src/main/kotlin/com/example/demo/fisherman/Fisherman.kt
+++ b/src/main/kotlin/com/example/demo/fisherman/Fisherman.kt
@@ -1,0 +1,22 @@
+package com.example.demo.fisherman
+
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "fisherman")
+class Fisherman(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long = 0,
+
+    @Column(unique = true, nullable = false)
+    var login: String = "",
+
+    @Column(nullable = false)
+    var password: String = "",
+
+    @Column(name = "secret_question", nullable = false)
+    var secretQuestion: String = "",
+
+    @Column(name = "secret_answer", nullable = false)
+    var secretAnswer: String = ""
+)

--- a/src/main/kotlin/com/example/demo/fisherman/FishermanController.kt
+++ b/src/main/kotlin/com/example/demo/fisherman/FishermanController.kt
@@ -1,0 +1,83 @@
+package com.example.demo.fisherman
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import jakarta.servlet.http.HttpSession
+
+@RestController
+class FishermanController(private val repository: FishermanRepository) {
+
+    private val encoder = BCryptPasswordEncoder()
+
+    data class RegisterRequest(
+        val login: String,
+        val password: String,
+        val question: String,
+        val answer: String
+    )
+
+    @PostMapping("/register")
+    fun register(@RequestBody req: RegisterRequest): ResponseEntity<Void> {
+        if (repository.findByLogin(req.login) != null) {
+            return ResponseEntity.status(409).build()
+        }
+        val fisherman = Fisherman(
+            login = req.login,
+            password = encoder.encode(req.password),
+            secretQuestion = req.question,
+            secretAnswer = encoder.encode(req.answer)
+        )
+        repository.save(fisherman)
+        return ResponseEntity.ok().build()
+    }
+
+    data class SignInRequest(val login: String, val password: String)
+
+    @PostMapping("/sign-in")
+    fun signIn(@RequestBody req: SignInRequest, session: HttpSession): ResponseEntity<Void> {
+        val fisherman = repository.findByLogin(req.login) ?: return ResponseEntity.status(401).build()
+        return if (encoder.matches(req.password, fisherman.password)) {
+            session.setAttribute("user", fisherman.login)
+            ResponseEntity.ok().build()
+        } else {
+            ResponseEntity.status(401).build()
+        }
+    }
+
+    data class QuestionResponse(val question: String)
+
+    @GetMapping("/fisherman/{login}/secret-question")
+    fun secretQuestion(
+        @PathVariable login: String,
+        @RequestParam(required = false) answer: String?
+    ): ResponseEntity<Any> {
+        val fisherman = repository.findByLogin(login) ?: return ResponseEntity.notFound().build()
+        return if (answer == null) {
+            ResponseEntity.ok(QuestionResponse(fisherman.secretQuestion))
+        } else {
+            if (encoder.matches(answer, fisherman.secretAnswer)) {
+                ResponseEntity.ok().build()
+            } else {
+                ResponseEntity.status(401).build()
+            }
+        }
+    }
+
+    data class PasswordUpdateRequest(val newPassword: String)
+
+    @PatchMapping("/fisherman/{login}/password")
+    fun updatePassword(
+        @PathVariable login: String,
+        @RequestParam answer: String,
+        @RequestBody req: PasswordUpdateRequest
+    ): ResponseEntity<Void> {
+        val fisherman = repository.findByLogin(login) ?: return ResponseEntity.notFound().build()
+        if (!encoder.matches(answer, fisherman.secretAnswer)) {
+            return ResponseEntity.status(401).build()
+        }
+        fisherman.password = encoder.encode(req.newPassword)
+        repository.save(fisherman)
+        return ResponseEntity.ok().build()
+    }
+}

--- a/src/main/kotlin/com/example/demo/fisherman/FishermanRepository.kt
+++ b/src/main/kotlin/com/example/demo/fisherman/FishermanRepository.kt
@@ -1,0 +1,7 @@
+package com.example.demo.fisherman
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface FishermanRepository : JpaRepository<Fisherman, Long> {
+    fun findByLogin(login: String): Fisherman?
+}

--- a/src/main/resources/db/migration/V2__create_fisherman.sql
+++ b/src/main/resources/db/migration/V2__create_fisherman.sql
@@ -1,0 +1,7 @@
+CREATE TABLE fisherman (
+    id SERIAL PRIMARY KEY,
+    login TEXT UNIQUE NOT NULL,
+    password TEXT NOT NULL,
+    secret_question TEXT NOT NULL,
+    secret_answer TEXT NOT NULL
+);

--- a/src/main/resources/static/forgot.html
+++ b/src/main/resources/static/forgot.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <title>Réinitialisation</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
+</head>
+<body class="d-flex justify-content-center align-items-center min-vh-100">
+  <div class="container" style="max-width: 400px;">
+    <div id="step1">
+      <div class="mb-3">
+        <label for="login" class="form-label">Identifiant</label>
+        <input type="text" class="form-control" id="login" />
+      </div>
+      <button id="getQuestion" class="btn btn-primary w-100">Récupérer la question</button>
+    </div>
+    <div id="step2" style="display:none;">
+      <p id="question" class="fw-bold"></p>
+      <div class="mb-3">
+        <label for="answer" class="form-label">Réponse secrète</label>
+        <input type="text" class="form-control" id="answer" />
+      </div>
+      <div class="mb-3">
+        <label for="newPassword" class="form-label">Nouveau mot de passe</label>
+        <input type="password" class="form-control" id="newPassword" />
+      </div>
+      <button id="resetPassword" class="btn btn-primary w-100">Mettre à jour</button>
+    </div>
+  </div>
+  <script>
+    const step1 = document.getElementById('step1');
+    const step2 = document.getElementById('step2');
+    document.getElementById('getQuestion').addEventListener('click', async () => {
+      const login = document.getElementById('login').value;
+      const res = await fetch(`/fisherman/${login}/secret-question`);
+      if (res.ok) {
+        const data = await res.json();
+        document.getElementById('question').innerText = data.question;
+        step1.style.display = 'none';
+        step2.style.display = 'block';
+      }
+    });
+    document.getElementById('resetPassword').addEventListener('click', async () => {
+      const login = document.getElementById('login').value;
+      const answer = document.getElementById('answer').value;
+      const newPassword = document.getElementById('newPassword').value;
+      const verify = await fetch(`/fisherman/${login}/secret-question?answer=${encodeURIComponent(answer)}`);
+      if (!verify.ok) return;
+      await fetch(`/fisherman/${login}/password?answer=${encodeURIComponent(answer)}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ newPassword })
+      });
+      window.location.href = 'index.html';
+    });
+  </script>
+</body>
+</html>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,11 +1,29 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fr">
 <head>
   <meta charset="UTF-8" />
-  <title>Fishing Copilot</title>
+  <title>Connexion</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
 </head>
-<body>
-  <h1>Welcome to Fishing Copilot</h1>
+<body class="d-flex justify-content-center align-items-center min-vh-100">
+  <div class="container" style="max-width: 400px;">
+    <form id="loginForm">
+      <div class="mb-3">
+        <label for="login" class="form-label">Identifiant</label>
+        <input type="text" class="form-control" id="login" required />
+      </div>
+      <div class="mb-3">
+        <label for="password" class="form-label">Mot de passe</label>
+        <input type="password" class="form-control" id="password" required />
+      </div>
+      <button type="submit" class="btn btn-primary w-100">SE CONNECTER</button>
+    </form>
+    <button id="openRegister" class="btn btn-link w-100 mt-2">s'enregistrer</button>
+    <div class="text-center mt-2">
+      <a href="forgot.html">mot de passe oublié</a>
+    </div>
+  </div>
   <script src="main.js"></script>
 </body>
 </html>

--- a/src/main/resources/static/main.js
+++ b/src/main/resources/static/main.js
@@ -1,3 +1,18 @@
 document.addEventListener('DOMContentLoaded', () => {
-  console.log('Frontend loaded');
+  const form = document.getElementById('loginForm');
+  if (form) {
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const login = document.getElementById('login').value;
+      const password = document.getElementById('password').value;
+      await fetch('/sign-in', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ login, password }),
+      });
+    });
+    document.getElementById('openRegister').addEventListener('click', () => {
+      window.location.href = 'register.html';
+    });
+  }
 });

--- a/src/main/resources/static/register.html
+++ b/src/main/resources/static/register.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <title>Enregistrement</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
+</head>
+<body class="d-flex justify-content-center align-items-center min-vh-100">
+  <div class="container" style="max-width: 400px;">
+    <form id="registerForm">
+      <div class="mb-3">
+        <label for="login" class="form-label">Identifiant</label>
+        <input type="text" class="form-control" id="login" required />
+      </div>
+      <div class="mb-3">
+        <label for="password" class="form-label">Mot de passe</label>
+        <input type="password" class="form-control" id="password" required />
+      </div>
+      <div class="mb-3">
+        <label for="question" class="form-label">Question secrète</label>
+        <input type="text" class="form-control" id="question" required />
+      </div>
+      <div class="mb-3">
+        <label for="answer" class="form-label">Réponse</label>
+        <input type="text" class="form-control" id="answer" required />
+      </div>
+      <button type="submit" class="btn btn-primary w-100">S'enregistrer</button>
+    </form>
+  </div>
+  <script>
+    document.getElementById('registerForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const login = document.getElementById('login').value;
+      const password = document.getElementById('password').value;
+      const question = document.getElementById('question').value;
+      const answer = document.getElementById('answer').value;
+      await fetch('/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ login, password, question, answer })
+      });
+      window.location.href = 'index.html';
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Fisherman entity, repository and controller for registration, sign-in and password reset
- store bcrypt-hashed credentials and secret answers
- create Bootstrap-based login, registration and password reset pages

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f05fc8b88325b5743fb394adf09f