### PR TITLE
Add Swagger documentation for API

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,19 @@ Pour lancer l'application :
 ```
 
 L'interface statique est disponible sur `http://localhost:8080/`.
+
+## Documentation API
+
+Une documentation OpenAPI est disponible après le démarrage de l'application :
+
+- Swagger UI : `http://localhost:8080/swagger-ui.html`
+- Spécification JSON : `http://localhost:8080/v3/api-docs`
+
+### Endpoints
+
+| Méthode | Chemin | Description |
+|---------|--------|-------------|
+| POST | `/register` | Enregistre un nouveau pêcheur |
+| POST | `/sign-in` | Authentifie un pêcheur |
+| GET | `/fisherman/{login}/secret-question` | Récupère la question secrète ou vérifie la réponse |
+| PATCH | `/fisherman/{login}/password` | Met à jour le mot de passe après validation de la réponse secrète |

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,11 @@
                         <artifactId>spring-boot-starter-web</artifactId>
                 </dependency>
                 <dependency>
+                        <groupId>org.springdoc</groupId>
+                        <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+                        <version>2.8.9</version>
+                </dependency>
+                <dependency>
                         <groupId>org.springframework.security</groupId>
                         <artifactId>spring-security-crypto</artifactId>
                 </dependency>

--- a/src/main/kotlin/com/example/demo/SwaggerConfig.kt
+++ b/src/main/kotlin/com/example/demo/SwaggerConfig.kt
@@ -1,0 +1,19 @@
+package com.example.demo
+
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class SwaggerConfig {
+
+    @Bean
+    fun openAPI(): OpenAPI = OpenAPI().info(
+        Info()
+            .title("Fishing Copilot API")
+            .description("API for managing fisherman accounts")
+            .version("1.0")
+    )
+}
+

--- a/src/main/kotlin/com/example/demo/fisherman/FishermanController.kt
+++ b/src/main/kotlin/com/example/demo/fisherman/FishermanController.kt
@@ -1,10 +1,13 @@
 package com.example.demo.fisherman
 
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 
 @RestController
+@Tag(name = "Fisherman", description = "Operations related to fisherman accounts")
 class FishermanController(private val repository: FishermanRepository) {
 
     private val encoder = BCryptPasswordEncoder()
@@ -17,6 +20,7 @@ class FishermanController(private val repository: FishermanRepository) {
     )
 
     @PostMapping("/register")
+    @Operation(summary = "Register a new fisherman", description = "Creates a new fisherman account with a secret question and answer")
     fun register(@RequestBody req: RegisterRequest): ResponseEntity<Void> {
         if (repository.findByUsername(req.username) != null) {
             return ResponseEntity.status(409).build()
@@ -34,6 +38,7 @@ class FishermanController(private val repository: FishermanRepository) {
     data class SignInRequest(val login: String, val password: String)
 
     @PostMapping("/sign-in")
+    @Operation(summary = "Sign in", description = "Authenticates a fisherman using username and password")
     fun signIn(@RequestBody req: SignInRequest): ResponseEntity<Void> {
         val fisherman = repository.findByUsername(req.login) ?: return ResponseEntity.status(401).build()
         return if (encoder.matches(req.password, fisherman.password)) {
@@ -46,6 +51,7 @@ class FishermanController(private val repository: FishermanRepository) {
     data class QuestionResponse(val question: String)
 
     @GetMapping("/fisherman/{login}/secret-question")
+    @Operation(summary = "Get or validate secret question", description = "Returns the fisherman's secret question or checks the provided answer")
     fun secretQuestion(
         @PathVariable login: String,
         @RequestParam(required = false) answer: String?
@@ -65,6 +71,7 @@ class FishermanController(private val repository: FishermanRepository) {
     data class PasswordUpdateRequest(val newPassword: String)
 
     @PatchMapping("/fisherman/{login}/password")
+    @Operation(summary = "Update password", description = "Updates the password after validating the secret answer")
     fun updatePassword(
         @PathVariable login: String,
         @RequestParam answer: String,


### PR DESCRIPTION
## Summary
- integrate springdoc OpenAPI to provide Swagger UI
- document fisherman endpoints with annotations
- describe available API endpoints in README

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f5dad0a08325ab1756ccd3c7eaaf