### PR TITLE
feat: manage fishing rods within sessions

### DIFF
--- a/src/main/kotlin/com/ggc/fishingcopilot/fishingsession/controller/FishingSessionController.kt
+++ b/src/main/kotlin/com/ggc/fishingcopilot/fishingsession/controller/FishingSessionController.kt
@@ -2,6 +2,9 @@ package com.ggc.fishingcopilot.fishingsession.controller
 
 import com.ggc.fishingcopilot.fishingsession.model.dto.CreateFishingSessionRequest
 import com.ggc.fishingcopilot.fishingsession.model.dto.FishingSessionResponse
+import com.ggc.fishingcopilot.fishingsession.rod.FishingRodService
+import com.ggc.fishingcopilot.fishingsession.rod.model.dto.RodResponse
+import com.ggc.fishingcopilot.fishingsession.rod.model.dto.UpdateRodRequest
 import com.ggc.fishingcopilot.fishingsession.service.FishingSessionService
 import io.swagger.v3.oas.annotations.Operation
 import org.springframework.http.ResponseEntity
@@ -9,7 +12,10 @@ import org.springframework.web.bind.annotation.*
 import java.util.UUID
 
 @RestController
-class FishingSessionController(private val service: FishingSessionService) {
+class FishingSessionController(
+    private val service: FishingSessionService,
+    private val rodService: FishingRodService
+) {
 
     @PostMapping("/fishing-session/create")
     @Operation(summary = "Create fishing session", description = "Create a new fishing session for the user")
@@ -33,6 +39,40 @@ class FishingSessionController(private val service: FishingSessionService) {
     @Operation(summary = "Close current fishing session", description = "Close the current IN_PROGRESS session")
     fun close(@RequestHeader("sessionId") sessionId: UUID): ResponseEntity<Void> {
         service.close(sessionId)
+        return ResponseEntity.ok().build()
+    }
+
+    @PostMapping("/fishing-session/{sessionId}/rods")
+    @Operation(summary = "Add fishing rod", description = "Add a fishing rod to the session")
+    fun addRod(
+        @RequestHeader("sessionId") sessionId: UUID,
+        @PathVariable("sessionId") fishingSessionId: Int
+    ): ResponseEntity<RodResponse> {
+        val rod = rodService.addRod(sessionId, fishingSessionId)
+        return ResponseEntity.ok(RodResponse(rod.id, rod.fishCount))
+    }
+
+    @PatchMapping("/fishing-session/{sessionId}/rod/{rodId}")
+    @Operation(summary = "Update rod fish count", description = "Update the fish count of a rod")
+    fun updateRod(
+        @RequestHeader("sessionId") sessionId: UUID,
+        @PathVariable("sessionId") fishingSessionId: Int,
+        @PathVariable rodId: Int,
+        @RequestBody req: UpdateRodRequest
+    ): ResponseEntity<RodResponse> {
+        val rod = rodService.updateRod(sessionId, fishingSessionId, rodId, req.fishCount)
+            ?: return ResponseEntity.notFound().build()
+        return ResponseEntity.ok(RodResponse(rod.id, rod.fishCount))
+    }
+
+    @DeleteMapping("/fishing-session/{sessionId}/rod/{rodId}")
+    @Operation(summary = "Delete fishing rod", description = "Delete a fishing rod from the session")
+    fun deleteRod(
+        @RequestHeader("sessionId") sessionId: UUID,
+        @PathVariable("sessionId") fishingSessionId: Int,
+        @PathVariable rodId: Int
+    ): ResponseEntity<Void> {
+        rodService.deleteRod(sessionId, fishingSessionId, rodId)
         return ResponseEntity.ok().build()
     }
 }

--- a/src/main/kotlin/com/ggc/fishingcopilot/fishingsession/rod/FishingRodRepository.kt
+++ b/src/main/kotlin/com/ggc/fishingcopilot/fishingsession/rod/FishingRodRepository.kt
@@ -1,0 +1,9 @@
+package com.ggc.fishingcopilot.fishingsession.rod
+
+import com.ggc.fishingcopilot.fishingsession.rod.model.entity.FishingRod
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface FishingRodRepository : JpaRepository<FishingRod, Int> {
+    fun findByIdAndFishingSessionId(id: Int, fishingSessionId: Int): FishingRod?
+    fun deleteByIdAndFishingSessionId(id: Int, fishingSessionId: Int)
+}

--- a/src/main/kotlin/com/ggc/fishingcopilot/fishingsession/rod/FishingRodService.kt
+++ b/src/main/kotlin/com/ggc/fishingcopilot/fishingsession/rod/FishingRodService.kt
@@ -1,0 +1,42 @@
+package com.ggc.fishingcopilot.fishingsession.rod
+
+import com.ggc.fishingcopilot.fishingsession.FishingSessionRepository
+import com.ggc.fishingcopilot.fishingsession.rod.model.entity.FishingRod
+import com.ggc.fishingcopilot.session.UserSessionRepository
+import com.ggc.fishingcopilot.fisherman.exception.SessionNotFoundException
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+@Service
+class FishingRodService(
+    private val sessionRepository: UserSessionRepository,
+    private val fishingSessionRepository: FishingSessionRepository,
+    private val rodRepository: FishingRodRepository
+) {
+    fun addRod(sessionId: UUID, fishingSessionId: Int): FishingRod {
+        val session = sessionRepository.findById(sessionId).orElseThrow { SessionNotFoundException() }
+        val fishingSession = fishingSessionRepository.findById(fishingSessionId)
+            .filter { it.fisherman == session.fisherman }
+            .orElseThrow { SessionNotFoundException() }
+        val rod = FishingRod(fishingSession = fishingSession)
+        return rodRepository.save(rod)
+    }
+
+    fun updateRod(sessionId: UUID, fishingSessionId: Int, rodId: Int, fishCount: Int): FishingRod? {
+        val session = sessionRepository.findById(sessionId).orElseThrow { SessionNotFoundException() }
+        val fishingSession = fishingSessionRepository.findById(fishingSessionId)
+            .filter { it.fisherman == session.fisherman }
+            .orElseThrow { SessionNotFoundException() }
+        val rod = rodRepository.findByIdAndFishingSessionId(rodId, fishingSession.id) ?: return null
+        rod.fishCount = fishCount
+        return rodRepository.save(rod)
+    }
+
+    fun deleteRod(sessionId: UUID, fishingSessionId: Int, rodId: Int) {
+        val session = sessionRepository.findById(sessionId).orElseThrow { SessionNotFoundException() }
+        val fishingSession = fishingSessionRepository.findById(fishingSessionId)
+            .filter { it.fisherman == session.fisherman }
+            .orElseThrow { SessionNotFoundException() }
+        rodRepository.deleteByIdAndFishingSessionId(rodId, fishingSession.id)
+    }
+}

--- a/src/main/kotlin/com/ggc/fishingcopilot/fishingsession/rod/model/dto/FishingRodDto.kt
+++ b/src/main/kotlin/com/ggc/fishingcopilot/fishingsession/rod/model/dto/FishingRodDto.kt
@@ -1,0 +1,10 @@
+package com.ggc.fishingcopilot.fishingsession.rod.model.dto
+
+data class RodResponse(
+    val id: Int,
+    val fishCount: Int
+)
+
+data class UpdateRodRequest(
+    val fishCount: Int
+)

--- a/src/main/kotlin/com/ggc/fishingcopilot/fishingsession/rod/model/entity/FishingRod.kt
+++ b/src/main/kotlin/com/ggc/fishingcopilot/fishingsession/rod/model/entity/FishingRod.kt
@@ -1,0 +1,26 @@
+package com.ggc.fishingcopilot.fishingsession.rod.model.entity
+
+import com.ggc.fishingcopilot.fishingsession.model.entity.FishingSession
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "fishing_rod")
+class FishingRod(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Int = 0,
+
+    @Column(name = "fish_count", nullable = false)
+    var fishCount: Int = 0,
+
+    @ManyToOne
+    @JoinColumn(name = "session_id", nullable = false)
+    var fishingSession: FishingSession
+)

--- a/src/main/resources/db/migration/V4__add_fishing_rod.sql
+++ b/src/main/resources/db/migration/V4__add_fishing_rod.sql
@@ -1,0 +1,5 @@
+CREATE TABLE fishing_rod (
+    id SERIAL PRIMARY KEY,
+    fish_count INT NOT NULL DEFAULT 0,
+    session_id INT NOT NULL REFERENCES fishing_session(id) ON DELETE CASCADE
+);

--- a/src/main/resources/static/main.js
+++ b/src/main/resources/static/main.js
@@ -111,6 +111,77 @@ document.addEventListener('DOMContentLoaded', async () => {
       window.location.href = 'home.html';
       return;
     }
+
+    const rodContainer = document.getElementById('rodContainer');
+    const addRodBtn = document.getElementById('addRod');
+
+    function createRodCard(rod) {
+      const card = document.createElement('div');
+      card.className = 'card m-3 p-3 d-flex justify-content-between align-items-center';
+
+      const timer = document.createElement('span');
+      timer.textContent = '00:00';
+      timer.style.fontFamily = 'DS-Digital';
+      timer.className = 'display-6';
+
+      const counter = document.createElement('div');
+      counter.className = 'd-flex align-items-center';
+
+      const minus = document.createElement('button');
+      minus.className = 'btn btn-outline-secondary btn-sm';
+      minus.textContent = '-';
+
+      const count = document.createElement('span');
+      count.className = 'mx-2';
+      count.textContent = rod.fishCount;
+
+      const plus = document.createElement('button');
+      plus.className = 'btn btn-outline-secondary btn-sm';
+      plus.textContent = '+';
+
+      minus.addEventListener('click', async () => {
+        if (rod.fishCount > 0) {
+          rod.fishCount--;
+          count.textContent = rod.fishCount;
+          await fetch(`/fishing-session/${current.id}/rod/${rod.id}`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json', sessionId },
+            body: JSON.stringify({ fishCount: rod.fishCount }),
+          });
+        }
+      });
+
+      plus.addEventListener('click', async () => {
+        rod.fishCount++;
+        count.textContent = rod.fishCount;
+        await fetch(`/fishing-session/${current.id}/rod/${rod.id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json', sessionId },
+          body: JSON.stringify({ fishCount: rod.fishCount }),
+        });
+      });
+
+      counter.appendChild(minus);
+      counter.appendChild(count);
+      counter.appendChild(plus);
+      card.appendChild(timer);
+      card.appendChild(counter);
+      rodContainer.appendChild(card);
+    }
+
+    if (addRodBtn) {
+      addRodBtn.addEventListener('click', async () => {
+        const resp = await fetch(`/fishing-session/${current.id}/rods`, {
+          method: 'POST',
+          headers: { sessionId },
+        });
+        if (resp.ok) {
+          const data = await resp.json();
+          createRodCard(data);
+        }
+      });
+    }
+
     closeBtn.addEventListener('click', async () => {
       await fetch('/fishing-session/close', {
         method: 'POST',

--- a/src/main/resources/static/session.html
+++ b/src/main/resources/static/session.html
@@ -5,18 +5,22 @@
   <title>Session</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link href="https://fonts.cdnfonts.com/css/ds-digital" rel="stylesheet" />
 </head>
-<body>
+<body class="d-flex flex-column vh-100">
   <header class="d-flex justify-content-between align-items-center p-2 border-bottom">
     <span id="usernameDisplay"></span>
     <button id="logoutBtn" class="btn btn-link">&#x23FB;</button>
   </header>
-  <div class="d-flex justify-content-center align-items-center min-vh-100">
-    <div class="container text-center" style="max-width: 400px;">
-      <h3>Session de pêche en cours</h3>
-      <button id="closeSession" class="btn btn-danger w-100 mt-3">Terminer la session</button>
+  <div class="position-relative flex-grow-1 d-flex flex-column">
+    <div class="position-absolute top-0 start-50 translate-middle-x mt-3">
+      <button id="addRod" class="btn btn-primary rounded-circle" style="width:3rem;height:3rem;font-size:1.5rem;">+</button>
     </div>
+    <div id="rodContainer" class="flex-grow-1 overflow-auto mt-5"></div>
   </div>
+  <footer class="p-2 border-top">
+    <button id="closeSession" class="btn btn-danger w-100">Terminer la session</button>
+  </footer>
   <script src="main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add database table and service layer to handle fishing rods
- expose REST endpoints to add, update, and remove rods on a fishing session
- enhance session page with UI to manage rod fish counters

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ba8b46cf548325927f5d6ae6a88638