### PR TITLE
Track fish per rod and improve session UI

### DIFF
--- a/src/main/kotlin/com/ggc/fishingcopilot/fishingsession/controller/FishingSessionController.kt
+++ b/src/main/kotlin/com/ggc/fishingcopilot/fishingsession/controller/FishingSessionController.kt
@@ -4,7 +4,6 @@ import com.ggc.fishingcopilot.fishingsession.model.dto.CreateFishingSessionReque
 import com.ggc.fishingcopilot.fishingsession.model.dto.FishingSessionResponse
 import com.ggc.fishingcopilot.fishingsession.rod.FishingRodService
 import com.ggc.fishingcopilot.fishingsession.rod.model.dto.RodResponse
-import com.ggc.fishingcopilot.fishingsession.rod.model.dto.UpdateRodRequest
 import com.ggc.fishingcopilot.fishingsession.service.FishingSessionService
 import io.swagger.v3.oas.annotations.Operation
 import org.springframework.http.ResponseEntity
@@ -49,20 +48,7 @@ class FishingSessionController(
         @PathVariable("sessionId") fishingSessionId: Int
     ): ResponseEntity<RodResponse> {
         val rod = rodService.addRod(sessionId, fishingSessionId)
-        return ResponseEntity.ok(RodResponse(rod.id, rod.fishCount))
-    }
-
-    @PatchMapping("/fishing-session/{sessionId}/rod/{rodId}")
-    @Operation(summary = "Update rod fish count", description = "Update the fish count of a rod")
-    fun updateRod(
-        @RequestHeader("sessionId") sessionId: UUID,
-        @PathVariable("sessionId") fishingSessionId: Int,
-        @PathVariable rodId: Int,
-        @RequestBody req: UpdateRodRequest
-    ): ResponseEntity<RodResponse> {
-        val rod = rodService.updateRod(sessionId, fishingSessionId, rodId, req.fishCount)
-            ?: return ResponseEntity.notFound().build()
-        return ResponseEntity.ok(RodResponse(rod.id, rod.fishCount))
+        return ResponseEntity.ok(RodResponse(rod.id, 0))
     }
 
     @DeleteMapping("/fishing-session/{sessionId}/rod/{rodId}")
@@ -74,5 +60,27 @@ class FishingSessionController(
     ): ResponseEntity<Void> {
         rodService.deleteRod(sessionId, fishingSessionId, rodId)
         return ResponseEntity.ok().build()
+    }
+
+    @PostMapping("/fishing-session/{sessionId}/rod/{rodId}/fish")
+    @Operation(summary = "Add fish", description = "Add a fish to the rod")
+    fun addFish(
+        @RequestHeader("sessionId") sessionId: UUID,
+        @PathVariable("sessionId") fishingSessionId: Int,
+        @PathVariable rodId: Int
+    ): ResponseEntity<RodResponse> {
+        val count = rodService.addFish(sessionId, fishingSessionId, rodId) ?: return ResponseEntity.notFound().build()
+        return ResponseEntity.ok(RodResponse(rodId, count))
+    }
+
+    @DeleteMapping("/fishing-session/{sessionId}/rod/{rodId}/fish")
+    @Operation(summary = "Remove last fish", description = "Remove the last fish from the rod")
+    fun removeFish(
+        @RequestHeader("sessionId") sessionId: UUID,
+        @PathVariable("sessionId") fishingSessionId: Int,
+        @PathVariable rodId: Int
+    ): ResponseEntity<RodResponse> {
+        val count = rodService.removeFish(sessionId, fishingSessionId, rodId) ?: return ResponseEntity.notFound().build()
+        return ResponseEntity.ok(RodResponse(rodId, count))
     }
 }

--- a/src/main/kotlin/com/ggc/fishingcopilot/fishingsession/rod/FishRepository.kt
+++ b/src/main/kotlin/com/ggc/fishingcopilot/fishingsession/rod/FishRepository.kt
@@ -1,0 +1,9 @@
+package com.ggc.fishingcopilot.fishingsession.rod
+
+import com.ggc.fishingcopilot.fishingsession.rod.model.entity.Fish
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface FishRepository : JpaRepository<Fish, Int> {
+    fun findTopByFishingRodIdOrderByCaughtAtDesc(fishingRodId: Int): Fish?
+    fun countByFishingRodId(fishingRodId: Int): Int
+}

--- a/src/main/kotlin/com/ggc/fishingcopilot/fishingsession/rod/FishingRodService.kt
+++ b/src/main/kotlin/com/ggc/fishingcopilot/fishingsession/rod/FishingRodService.kt
@@ -2,6 +2,7 @@ package com.ggc.fishingcopilot.fishingsession.rod
 
 import com.ggc.fishingcopilot.fishingsession.FishingSessionRepository
 import com.ggc.fishingcopilot.fishingsession.rod.model.entity.FishingRod
+import com.ggc.fishingcopilot.fishingsession.rod.model.entity.Fish
 import com.ggc.fishingcopilot.session.UserSessionRepository
 import com.ggc.fishingcopilot.fisherman.exception.SessionNotFoundException
 import org.springframework.stereotype.Service
@@ -11,7 +12,8 @@ import java.util.UUID
 class FishingRodService(
     private val sessionRepository: UserSessionRepository,
     private val fishingSessionRepository: FishingSessionRepository,
-    private val rodRepository: FishingRodRepository
+    private val rodRepository: FishingRodRepository,
+    private val fishRepository: FishRepository
 ) {
     fun addRod(sessionId: UUID, fishingSessionId: Int): FishingRod {
         val session = sessionRepository.findById(sessionId).orElseThrow { SessionNotFoundException() }
@@ -22,21 +24,32 @@ class FishingRodService(
         return rodRepository.save(rod)
     }
 
-    fun updateRod(sessionId: UUID, fishingSessionId: Int, rodId: Int, fishCount: Int): FishingRod? {
-        val session = sessionRepository.findById(sessionId).orElseThrow { SessionNotFoundException() }
-        val fishingSession = fishingSessionRepository.findById(fishingSessionId)
-            .filter { it.fisherman == session.fisherman }
-            .orElseThrow { SessionNotFoundException() }
-        val rod = rodRepository.findByIdAndFishingSessionId(rodId, fishingSession.id) ?: return null
-        rod.fishCount = fishCount
-        return rodRepository.save(rod)
-    }
-
     fun deleteRod(sessionId: UUID, fishingSessionId: Int, rodId: Int) {
         val session = sessionRepository.findById(sessionId).orElseThrow { SessionNotFoundException() }
         val fishingSession = fishingSessionRepository.findById(fishingSessionId)
             .filter { it.fisherman == session.fisherman }
             .orElseThrow { SessionNotFoundException() }
         rodRepository.deleteByIdAndFishingSessionId(rodId, fishingSession.id)
+    }
+
+    fun addFish(sessionId: UUID, fishingSessionId: Int, rodId: Int): Int? {
+        val session = sessionRepository.findById(sessionId).orElseThrow { SessionNotFoundException() }
+        val fishingSession = fishingSessionRepository.findById(fishingSessionId)
+            .filter { it.fisherman == session.fisherman }
+            .orElseThrow { SessionNotFoundException() }
+        val rod = rodRepository.findByIdAndFishingSessionId(rodId, fishingSession.id) ?: return null
+        fishRepository.save(Fish(fishingRod = rod))
+        return fishRepository.countByFishingRodId(rod.id)
+    }
+
+    fun removeFish(sessionId: UUID, fishingSessionId: Int, rodId: Int): Int? {
+        val session = sessionRepository.findById(sessionId).orElseThrow { SessionNotFoundException() }
+        val fishingSession = fishingSessionRepository.findById(fishingSessionId)
+            .filter { it.fisherman == session.fisherman }
+            .orElseThrow { SessionNotFoundException() }
+        val rod = rodRepository.findByIdAndFishingSessionId(rodId, fishingSession.id) ?: return null
+        val fish = fishRepository.findTopByFishingRodIdOrderByCaughtAtDesc(rod.id) ?: return fishRepository.countByFishingRodId(rod.id)
+        fishRepository.delete(fish)
+        return fishRepository.countByFishingRodId(rod.id)
     }
 }

--- a/src/main/kotlin/com/ggc/fishingcopilot/fishingsession/rod/model/dto/FishingRodDto.kt
+++ b/src/main/kotlin/com/ggc/fishingcopilot/fishingsession/rod/model/dto/FishingRodDto.kt
@@ -4,7 +4,3 @@ data class RodResponse(
     val id: Int,
     val fishCount: Int
 )
-
-data class UpdateRodRequest(
-    val fishCount: Int
-)

--- a/src/main/kotlin/com/ggc/fishingcopilot/fishingsession/rod/model/entity/Fish.kt
+++ b/src/main/kotlin/com/ggc/fishingcopilot/fishingsession/rod/model/entity/Fish.kt
@@ -1,0 +1,19 @@
+package com.ggc.fishingcopilot.fishingsession.rod.model.entity
+
+import jakarta.persistence.*
+import java.time.Instant
+
+@Entity
+@Table(name = "fish")
+class Fish(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Int = 0,
+
+    @Column(name = "caught_at", nullable = false)
+    var caughtAt: Instant = Instant.now(),
+
+    @ManyToOne
+    @JoinColumn(name = "rod_id", nullable = false)
+    var fishingRod: FishingRod
+)

--- a/src/main/kotlin/com/ggc/fishingcopilot/fishingsession/rod/model/entity/FishingRod.kt
+++ b/src/main/kotlin/com/ggc/fishingcopilot/fishingsession/rod/model/entity/FishingRod.kt
@@ -1,7 +1,6 @@
 package com.ggc.fishingcopilot.fishingsession.rod.model.entity
 
 import com.ggc.fishingcopilot.fishingsession.model.entity.FishingSession
-import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
@@ -16,9 +15,6 @@ class FishingRod(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Int = 0,
-
-    @Column(name = "fish_count", nullable = false)
-    var fishCount: Int = 0,
 
     @ManyToOne
     @JoinColumn(name = "session_id", nullable = false)

--- a/src/main/resources/db/migration/V5__add_fish_table.sql
+++ b/src/main/resources/db/migration/V5__add_fish_table.sql
@@ -1,0 +1,7 @@
+ALTER TABLE fishing_rod DROP COLUMN fish_count;
+
+CREATE TABLE fish (
+    id SERIAL PRIMARY KEY,
+    caught_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    rod_id INT NOT NULL REFERENCES fishing_rod(id) ON DELETE CASCADE
+);

--- a/src/main/resources/static/main.js
+++ b/src/main/resources/static/main.js
@@ -115,59 +115,77 @@ document.addEventListener('DOMContentLoaded', async () => {
     const rodContainer = document.getElementById('rodContainer');
     const addRodBtn = document.getElementById('addRod');
 
-    function createRodCard(rod) {
-      const card = document.createElement('div');
-      card.className = 'card m-3 p-3 d-flex justify-content-between align-items-center';
+      function createRodCard(rod) {
+        const card = document.createElement('div');
+        card.className = 'card m-3 p-3 d-flex align-items-center';
 
-      const timer = document.createElement('span');
-      timer.textContent = '00:00';
-      timer.style.fontFamily = 'DS-Digital';
-      timer.className = 'display-6';
+        const counter = document.createElement('div');
+        counter.className = 'd-flex align-items-center';
 
-      const counter = document.createElement('div');
-      counter.className = 'd-flex align-items-center';
+        const minus = document.createElement('button');
+        minus.className = 'btn btn-outline-secondary btn-sm';
+        minus.textContent = '-';
 
-      const minus = document.createElement('button');
-      minus.className = 'btn btn-outline-secondary btn-sm';
-      minus.textContent = '-';
-
-      const count = document.createElement('span');
-      count.className = 'mx-2';
-      count.textContent = rod.fishCount;
-
-      const plus = document.createElement('button');
-      plus.className = 'btn btn-outline-secondary btn-sm';
-      plus.textContent = '+';
-
-      minus.addEventListener('click', async () => {
-        if (rod.fishCount > 0) {
-          rod.fishCount--;
-          count.textContent = rod.fishCount;
-          await fetch(`/fishing-session/${current.id}/rod/${rod.id}`, {
-            method: 'PATCH',
-            headers: { 'Content-Type': 'application/json', sessionId },
-            body: JSON.stringify({ fishCount: rod.fishCount }),
-          });
-        }
-      });
-
-      plus.addEventListener('click', async () => {
-        rod.fishCount++;
+        const count = document.createElement('span');
+        count.className = 'mx-2';
         count.textContent = rod.fishCount;
-        await fetch(`/fishing-session/${current.id}/rod/${rod.id}`, {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json', sessionId },
-          body: JSON.stringify({ fishCount: rod.fishCount }),
-        });
-      });
 
-      counter.appendChild(minus);
-      counter.appendChild(count);
-      counter.appendChild(plus);
-      card.appendChild(timer);
-      card.appendChild(counter);
-      rodContainer.appendChild(card);
-    }
+        const plus = document.createElement('button');
+        plus.className = 'btn btn-outline-secondary btn-sm';
+        plus.textContent = '+';
+
+        counter.appendChild(minus);
+        counter.appendChild(count);
+        counter.appendChild(plus);
+
+        const timer = document.createElement('span');
+        timer.textContent = '00:00';
+        timer.style.fontFamily = 'DS-Digital';
+        timer.className = 'display-5 flex-grow-1 text-center';
+
+        const del = document.createElement('button');
+        del.className = 'btn btn-link text-danger ms-2';
+        del.textContent = '🗑️';
+
+        del.addEventListener('click', async () => {
+          if (confirm('Supprimer cette canne ?')) {
+            await fetch(`/fishing-session/${current.id}/rod/${rod.id}`, {
+              method: 'DELETE',
+              headers: { sessionId },
+            });
+            card.remove();
+          }
+        });
+
+        minus.addEventListener('click', async () => {
+          if (parseInt(count.textContent) > 0) {
+            const resp = await fetch(`/fishing-session/${current.id}/rod/${rod.id}/fish`, {
+              method: 'DELETE',
+              headers: { sessionId },
+            });
+            if (resp.ok) {
+              const data = await resp.json();
+              count.textContent = data.fishCount;
+            }
+          }
+        });
+
+        plus.addEventListener('click', async () => {
+          const resp = await fetch(`/fishing-session/${current.id}/rod/${rod.id}/fish`, {
+            method: 'POST',
+            headers: { sessionId },
+          });
+          if (resp.ok) {
+            const data = await resp.json();
+            count.textContent = data.fishCount;
+          }
+        });
+
+        card.appendChild(counter);
+        card.appendChild(timer);
+        card.appendChild(del);
+        rodContainer.appendChild(card);
+      }
 
     if (addRodBtn) {
       addRodBtn.addEventListener('click', async () => {

--- a/src/main/resources/static/session.html
+++ b/src/main/resources/static/session.html
@@ -14,7 +14,7 @@
   </header>
   <div class="position-relative flex-grow-1 d-flex flex-column">
     <div class="position-absolute top-0 start-50 translate-middle-x mt-3">
-      <button id="addRod" class="btn btn-primary rounded-circle" style="width:3rem;height:3rem;font-size:1.5rem;">+</button>
+      <button id="addRod" class="btn btn-primary rounded-circle d-flex align-items-center justify-content-center" style="width:3rem;height:3rem;font-size:1.5rem;">+</button>
     </div>
     <div id="rodContainer" class="flex-grow-1 overflow-auto mt-5"></div>
   </div>


### PR DESCRIPTION
## Summary
- add fish table and entity to store catches
- handle fish add/remove via new endpoints and service
- redesign rod card with centered timer and delete option

## Testing
- `mvn -q test` *(fails: Network is unreachable while resolving parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68ba958adb2c8325a1237180daa0b164