### PR TITLE
Afficher les cannes existantes lors de la reprise d'une session

### DIFF
--- a/src/main/kotlin/com/ggc/fishingcopilot/fishingsession/controller/FishingSessionController.kt
+++ b/src/main/kotlin/com/ggc/fishingcopilot/fishingsession/controller/FishingSessionController.kt
@@ -41,6 +41,16 @@ class FishingSessionController(
         return ResponseEntity.ok().build()
     }
 
+    @GetMapping("/fishing-session/{sessionId}/rods")
+    @Operation(summary = "List fishing rods", description = "List rods for the session")
+    fun listRods(
+        @RequestHeader("sessionId") sessionId: UUID,
+        @PathVariable("sessionId") fishingSessionId: Int
+    ): ResponseEntity<List<RodResponse>> {
+        val rods = rodService.getRods(sessionId, fishingSessionId)
+        return ResponseEntity.ok(rods)
+    }
+
     @PostMapping("/fishing-session/{sessionId}/rods")
     @Operation(summary = "Add fishing rod", description = "Add a fishing rod to the session")
     fun addRod(

--- a/src/main/kotlin/com/ggc/fishingcopilot/fishingsession/rod/FishingRodRepository.kt
+++ b/src/main/kotlin/com/ggc/fishingcopilot/fishingsession/rod/FishingRodRepository.kt
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 interface FishingRodRepository : JpaRepository<FishingRod, Int> {
     fun findByIdAndFishingSessionId(id: Int, fishingSessionId: Int): FishingRod?
     fun deleteByIdAndFishingSessionId(id: Int, fishingSessionId: Int)
+    fun findAllByFishingSessionId(fishingSessionId: Int): List<FishingRod>
 }

--- a/src/main/kotlin/com/ggc/fishingcopilot/fishingsession/rod/FishingRodService.kt
+++ b/src/main/kotlin/com/ggc/fishingcopilot/fishingsession/rod/FishingRodService.kt
@@ -3,6 +3,7 @@ package com.ggc.fishingcopilot.fishingsession.rod
 import com.ggc.fishingcopilot.fishingsession.FishingSessionRepository
 import com.ggc.fishingcopilot.fishingsession.rod.model.entity.FishingRod
 import com.ggc.fishingcopilot.fishingsession.rod.model.entity.Fish
+import com.ggc.fishingcopilot.fishingsession.rod.model.dto.RodResponse
 import com.ggc.fishingcopilot.session.UserSessionRepository
 import com.ggc.fishingcopilot.fisherman.exception.SessionNotFoundException
 import org.springframework.stereotype.Service
@@ -32,6 +33,17 @@ class FishingRodService(
             .filter { it.fisherman == session.fisherman }
             .orElseThrow { SessionNotFoundException() }
         rodRepository.deleteByIdAndFishingSessionId(rodId, fishingSession.id)
+    }
+
+    fun getRods(sessionId: UUID, fishingSessionId: Int): List<RodResponse> {
+        val session = sessionRepository.findById(sessionId).orElseThrow { SessionNotFoundException() }
+        val fishingSession = fishingSessionRepository.findById(fishingSessionId)
+            .filter { it.fisherman == session.fisherman }
+            .orElseThrow { SessionNotFoundException() }
+        return rodRepository.findAllByFishingSessionId(fishingSession.id).map { rod ->
+            val count = fishRepository.countByFishingRodId(rod.id)
+            RodResponse(rod.id, count)
+        }
     }
 
     fun addFish(sessionId: UUID, fishingSessionId: Int, rodId: Int): Int? {

--- a/src/main/resources/static/main.js
+++ b/src/main/resources/static/main.js
@@ -186,13 +186,18 @@ document.addEventListener('DOMContentLoaded', async () => {
         card.appendChild(del);
         rodContainer.appendChild(card);
       }
+      const rodsResp = await fetch(`/fishing-session/${current.id}/rods`, { headers: { sessionId } });
+      if (rodsResp.ok) {
+        const rods = await rodsResp.json();
+        rods.forEach(createRodCard);
+      }
 
-    if (addRodBtn) {
-      addRodBtn.addEventListener('click', async () => {
-        const resp = await fetch(`/fishing-session/${current.id}/rods`, {
-          method: 'POST',
-          headers: { sessionId },
-        });
+      if (addRodBtn) {
+        addRodBtn.addEventListener('click', async () => {
+          const resp = await fetch(`/fishing-session/${current.id}/rods`, {
+            method: 'POST',
+            headers: { sessionId },
+          });
         if (resp.ok) {
           const data = await resp.json();
           createRodCard(data);


### PR DESCRIPTION
## Summary
- expose `/fishing-session/{sessionId}/rods` to list rods with fish counts
- add service and repository methods to gather rods
- fetch and display existing rods on session page

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68baa25f21008325b0959f1f74e2da7f