### PR TITLE
Add toast notifications for API errors and registration success

### DIFF
--- a/src/main/resources/static/forgot.html
+++ b/src/main/resources/static/forgot.html
@@ -28,12 +28,13 @@
       <button id="resetPassword" class="btn btn-primary w-100">Mettre à jour</button>
     </div>
   </div>
+  <script src="utils.js"></script>
   <script>
     const step1 = document.getElementById('step1');
     const step2 = document.getElementById('step2');
     document.getElementById('getQuestion').addEventListener('click', async () => {
       const login = document.getElementById('login').value;
-      const res = await fetch(`/fisherman/${login}/secret-question`);
+      const res = await apiFetch(`/fisherman/${login}/secret-question`);
       if (res.ok) {
         const data = await res.json();
         document.getElementById('question').innerText = "question secrète: " + data.question;
@@ -45,14 +46,17 @@
       const login = document.getElementById('login').value;
       const answer = document.getElementById('answer').value;
       const newPassword = document.getElementById('newPassword').value;
-      const verify = await fetch(`/fisherman/${login}/secret-question?answer=${encodeURIComponent(answer)}`);
+      const verify = await apiFetch(`/fisherman/${login}/secret-question?answer=${encodeURIComponent(answer)}`);
       if (!verify.ok) return;
-      await fetch(`/fisherman/${login}/password?answer=${encodeURIComponent(answer)}`, {
+      const resp = await apiFetch(`/fisherman/${login}/password?answer=${encodeURIComponent(answer)}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ newPassword })
       });
-      window.location.href = 'index.html';
+      if (resp.ok) {
+        showToast('Mot de passe mis à jour', 'success');
+        setTimeout(() => { window.location.href = 'index.html'; }, 2000);
+      }
     });
   </script>
 </body>

--- a/src/main/resources/static/home.html
+++ b/src/main/resources/static/home.html
@@ -16,6 +16,7 @@
       <button id="startSession" class="btn btn-primary w-100">Démarrer une nouvelle session</button>
     </div>
   </div>
+  <script src="utils.js"></script>
   <script src="main.js"></script>
 </body>
 </html>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -24,6 +24,7 @@
       <a href="forgot.html">mot de passe oublié</a>
     </div>
   </div>
+  <script src="utils.js"></script>
   <script src="main.js"></script>
 </body>
 </html>

--- a/src/main/resources/static/main.js
+++ b/src/main/resources/static/main.js
@@ -3,7 +3,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   async function validateSession() {
     if (!sessionId) return false;
-    const resp = await fetch('/session/check', { headers: { sessionId } });
+    const resp = await apiFetch('/session/check', { headers: { sessionId } });
     if (resp.ok) {
       const username = await resp.text();
       localStorage.setItem('login', username);
@@ -16,7 +16,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   async function getCurrentFishingSession() {
-    const resp = await fetch('/fishing-session/current', { headers: { sessionId } });
+    const resp = await apiFetch('/fishing-session/current', { headers: { sessionId } });
     if (resp.status === 200) {
       const data = await resp.json();
       localStorage.setItem('currentFishingSessionId', data.id);
@@ -37,7 +37,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       e.preventDefault();
       const login = document.getElementById('login').value;
       const password = document.getElementById('password').value;
-      const resp = await fetch('/sign-in', {
+      const resp = await apiFetch('/sign-in', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ login, password }),
@@ -70,7 +70,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   const logoutBtn = document.getElementById('logoutBtn');
   if (logoutBtn) {
     logoutBtn.addEventListener('click', async () => {
-      await fetch('/fisherman/logout', { headers: { sessionId } });
+      await apiFetch('/fisherman/logout', { headers: { sessionId } });
       localStorage.removeItem('sessionId');
       localStorage.removeItem('login');
       localStorage.removeItem('currentFishingSessionId');
@@ -87,7 +87,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
     startBtn.addEventListener('click', async () => {
       const name = prompt('Nom de la session', 'sans nom') || 'sans nom';
-      const resp = await fetch('/fishing-session/create', {
+      const resp = await apiFetch('/fishing-session/create', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -149,7 +149,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         del.addEventListener('click', async () => {
           if (confirm('Supprimer cette canne ?')) {
-            await fetch(`/fishing-session/${current.id}/rod/${rod.id}`, {
+            await apiFetch(`/fishing-session/${current.id}/rod/${rod.id}`, {
               method: 'DELETE',
               headers: { sessionId },
             });
@@ -159,7 +159,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         minus.addEventListener('click', async () => {
           if (parseInt(count.textContent) > 0) {
-            const resp = await fetch(`/fishing-session/${current.id}/rod/${rod.id}/fish`, {
+            const resp = await apiFetch(`/fishing-session/${current.id}/rod/${rod.id}/fish`, {
               method: 'DELETE',
               headers: { sessionId },
             });
@@ -171,7 +171,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         });
 
         plus.addEventListener('click', async () => {
-          const resp = await fetch(`/fishing-session/${current.id}/rod/${rod.id}/fish`, {
+          const resp = await apiFetch(`/fishing-session/${current.id}/rod/${rod.id}/fish`, {
             method: 'POST',
             headers: { sessionId },
           });
@@ -186,7 +186,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         card.appendChild(del);
         rodContainer.appendChild(card);
       }
-      const rodsResp = await fetch(`/fishing-session/${current.id}/rods`, { headers: { sessionId } });
+      const rodsResp = await apiFetch(`/fishing-session/${current.id}/rods`, { headers: { sessionId } });
       if (rodsResp.ok) {
         const rods = await rodsResp.json();
         rods.forEach(createRodCard);
@@ -194,7 +194,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
       if (addRodBtn) {
         addRodBtn.addEventListener('click', async () => {
-          const resp = await fetch(`/fishing-session/${current.id}/rods`, {
+          const resp = await apiFetch(`/fishing-session/${current.id}/rods`, {
             method: 'POST',
             headers: { sessionId },
           });
@@ -206,7 +206,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     closeBtn.addEventListener('click', async () => {
-      await fetch('/fishing-session/close', {
+      await apiFetch('/fishing-session/close', {
         method: 'POST',
         headers: { sessionId },
       });

--- a/src/main/resources/static/register.html
+++ b/src/main/resources/static/register.html
@@ -28,6 +28,7 @@
       <button type="submit" class="btn btn-primary w-100">S'enregistrer</button>
     </form>
   </div>
+  <script src="utils.js"></script>
   <script>
     document.getElementById('registerForm').addEventListener('submit', async (e) => {
       e.preventDefault();
@@ -35,12 +36,15 @@
       const password = document.getElementById('password').value;
       const question = document.getElementById('question').value;
       const answer = document.getElementById('answer').value;
-      await fetch('/register', {
+      const resp = await apiFetch('/register', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, password, question, answer })
       });
-      //window.location.href = 'index.html';
+      if (resp.ok) {
+        showToast('compte correctement créer vous pouvez vous connecter', 'success');
+        setTimeout(() => { window.location.href = 'index.html'; }, 2000);
+      }
     });
   </script>
 </body>

--- a/src/main/resources/static/session.html
+++ b/src/main/resources/static/session.html
@@ -21,6 +21,7 @@
   <footer class="p-2 border-top">
     <button id="closeSession" class="btn btn-danger w-100">Terminer la session</button>
   </footer>
+  <script src="utils.js"></script>
   <script src="main.js"></script>
 </body>
 </html>

--- a/src/main/resources/static/utils.js
+++ b/src/main/resources/static/utils.js
@@ -1,0 +1,30 @@
+function showToast(message, type = 'info') {
+  const alert = document.createElement('div');
+  alert.className = `alert alert-${type} position-fixed top-0 end-0 m-3`;
+  alert.style.zIndex = 9999;
+  alert.textContent = message;
+  document.body.appendChild(alert);
+  setTimeout(() => alert.remove(), 5000);
+}
+
+async function apiFetch(url, options) {
+  const resp = await fetch(url, options);
+  if (!resp.ok) {
+    const status = resp.status;
+    const messages = {
+      400: 'Requête invalide',
+      401: 'Non autorisé',
+      403: 'Accès interdit',
+      404: 'Ressource introuvable',
+      409: 'Conflit',
+      500: 'Erreur interne du serveur',
+      503: 'Service indisponible'
+    };
+    const msg = messages[status] || `Erreur ${status}`;
+    showToast(msg, status >= 500 ? 'danger' : 'warning');
+  }
+  return resp;
+}
+
+window.showToast = showToast;
+window.apiFetch = apiFetch;


### PR DESCRIPTION
## Summary
- Show Bootstrap alerts for backend error and warning responses
- Display success toast after account registration

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bacc197a408325b19c3d3b52134d3b