### PR TITLE
feat: add interactive timer for rods

### DIFF
--- a/src/main/resources/static/session.html
+++ b/src/main/resources/static/session.html
@@ -6,6 +6,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link href="https://fonts.cdnfonts.com/css/ds-digital" rel="stylesheet" />
+  <style>
+    @keyframes blink {
+      50% { opacity: 0.6; }
+    }
+    .blink {
+      animation: blink 1s linear infinite;
+    }
+    #timerDialog { z-index: 1050; }
+  </style>
 </head>
 <body class="d-flex flex-column vh-100">
   <header class="d-flex justify-content-between align-items-center p-2 border-bottom">
@@ -21,6 +30,16 @@
   <footer class="p-2 border-top">
     <button id="closeSession" class="btn btn-danger w-100">Terminer la session</button>
   </footer>
+
+  <div id="timerDialog" class="d-none position-fixed top-0 start-0 w-100 h-100 bg-dark bg-opacity-50 justify-content-center align-items-center">
+    <div class="bg-white p-4 rounded">
+      <input type="number" id="timerMinutes" class="form-control mb-3 text-center" min="1" max="180" value="5" />
+      <div class="text-end">
+        <button id="timerCancel" class="btn btn-secondary me-2">Annuler</button>
+        <button id="timerOk" class="btn btn-primary">OK</button>
+      </div>
+    </div>
+  </div>
   <script src="utils.js"></script>
   <script src="main.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- allow rods to run a countdown timer with adjustable duration
- highlight active rods with a blinking green background and turn them red when time elapses

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0b7511f48325b6575b80ede9c0a3