### PR TITLE
Improve session layout and timer UX

### DIFF
--- a/src/main/resources/static/forgot.html
+++ b/src/main/resources/static/forgot.html
@@ -4,6 +4,9 @@
   <meta charset="UTF-8" />
   <title>Réinitialisation</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+  <meta http-equiv="Pragma" content="no-cache" />
+  <meta http-equiv="Expires" content="0" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
 </head>
 <body class="d-flex justify-content-center align-items-center min-vh-100">
@@ -28,7 +31,7 @@
       <button id="resetPassword" class="btn btn-primary w-100">Mettre à jour</button>
     </div>
   </div>
-  <script src="utils.js"></script>
+  <script src="utils.js?v=1"></script>
   <script>
     const step1 = document.getElementById('step1');
     const step2 = document.getElementById('step2');

--- a/src/main/resources/static/home.html
+++ b/src/main/resources/static/home.html
@@ -4,6 +4,9 @@
   <meta charset="UTF-8" />
   <title>Accueil</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+  <meta http-equiv="Pragma" content="no-cache" />
+  <meta http-equiv="Expires" content="0" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
 </head>
 <body>
@@ -16,7 +19,7 @@
       <button id="startSession" class="btn btn-primary w-100">Démarrer une nouvelle session</button>
     </div>
   </div>
-  <script src="utils.js"></script>
-  <script src="main.js"></script>
+  <script src="utils.js?v=1"></script>
+  <script src="main.js?v=1"></script>
 </body>
 </html>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -4,6 +4,9 @@
   <meta charset="UTF-8" />
   <title>Connexion</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+  <meta http-equiv="Pragma" content="no-cache" />
+  <meta http-equiv="Expires" content="0" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
 </head>
 <body class="d-flex justify-content-center align-items-center min-vh-100">
@@ -24,7 +27,7 @@
       <a href="forgot.html">mot de passe oublié</a>
     </div>
   </div>
-  <script src="utils.js"></script>
-  <script src="main.js"></script>
+  <script src="utils.js?v=1"></script>
+  <script src="main.js?v=1"></script>
 </body>
 </html>

--- a/src/main/resources/static/main.js
+++ b/src/main/resources/static/main.js
@@ -132,6 +132,14 @@ document.addEventListener('DOMContentLoaded', async () => {
       if (resolveTimerDialog) resolveTimerDialog(minutes);
     });
     function openTimerDialog(initial) {
+      if (timerMinutes.options.length === 0) {
+        for (let i = 1; i <= 180; i++) {
+          const opt = document.createElement('option');
+          opt.value = i;
+          opt.textContent = i;
+          timerMinutes.appendChild(opt);
+        }
+      }
       timerMinutes.value = initial || 5;
       timerDialog.classList.remove('d-none');
       timerDialog.classList.add('d-flex');
@@ -143,14 +151,14 @@ document.addEventListener('DOMContentLoaded', async () => {
         card.className = 'card m-3 p-3 d-flex align-items-center';
 
         const counter = document.createElement('div');
-        counter.className = 'd-flex align-items-center';
+        counter.className = 'd-flex align-items-center bg-white rounded p-1';
 
         const minus = document.createElement('button');
         minus.className = 'btn btn-outline-secondary btn-sm';
         minus.textContent = '-';
 
         const count = document.createElement('span');
-        count.className = 'mx-2';
+        count.className = 'mx-2 fw-bold';
         count.textContent = rod.fishCount;
 
         const plus = document.createElement('button');
@@ -167,7 +175,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         timer.className = 'display-5 flex-grow-1 text-center';
 
         const del = document.createElement('button');
-        del.className = 'btn btn-link text-danger ms-2';
+        del.className = 'btn btn-outline-danger ms-2';
         del.textContent = '🗑️';
 
         del.addEventListener('click', async () => {
@@ -201,6 +209,14 @@ document.addEventListener('DOMContentLoaded', async () => {
           if (resp.ok) {
             const data = await resp.json();
             count.textContent = data.fishCount;
+            if (intervalId) {
+              clearInterval(intervalId);
+              intervalId = null;
+            }
+            remaining = duration;
+            updateTimerDisplay();
+            card.classList.remove('bg-success', 'blink', 'border', 'border-danger');
+            timer.classList.remove('text-danger');
           }
         });
 
@@ -235,6 +251,9 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         timer.addEventListener('click', async (e) => {
           e.stopPropagation();
+          if (intervalId && !confirm('Changer la durée du timer ?')) {
+            return;
+          }
           const minutes = await openTimerDialog(duration / 60);
           if (minutes) {
             duration = minutes * 60;
@@ -244,7 +263,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         });
 
         card.addEventListener('click', () => {
-          if (!intervalId && duration > 0 && remaining === 0) {
+          if (!intervalId && duration > 0) {
             startCountdown();
           }
         });

--- a/src/main/resources/static/register.html
+++ b/src/main/resources/static/register.html
@@ -4,6 +4,9 @@
   <meta charset="UTF-8" />
   <title>Enregistrement</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+  <meta http-equiv="Pragma" content="no-cache" />
+  <meta http-equiv="Expires" content="0" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
 </head>
 <body class="d-flex justify-content-center align-items-center min-vh-100">
@@ -28,7 +31,7 @@
       <button type="submit" class="btn btn-primary w-100">S'enregistrer</button>
     </form>
   </div>
-  <script src="utils.js"></script>
+  <script src="utils.js?v=1"></script>
   <script>
     document.getElementById('registerForm').addEventListener('submit', async (e) => {
       e.preventDefault();

--- a/src/main/resources/static/session.html
+++ b/src/main/resources/static/session.html
@@ -4,6 +4,9 @@
   <meta charset="UTF-8" />
   <title>Session</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+  <meta http-equiv="Pragma" content="no-cache" />
+  <meta http-equiv="Expires" content="0" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link href="https://fonts.cdnfonts.com/css/ds-digital" rel="stylesheet" />
   <style>
@@ -16,31 +19,32 @@
     #timerDialog { z-index: 1050; }
   </style>
 </head>
-<body class="d-flex flex-column vh-100">
+<body class="d-flex flex-column min-vh-100 overflow-hidden">
   <header class="d-flex justify-content-between align-items-center p-2 border-bottom">
     <span id="usernameDisplay"></span>
     <button id="logoutBtn" class="btn btn-link">&#x23FB;</button>
   </header>
-  <div class="position-relative flex-grow-1 d-flex flex-column">
+  <div class="position-relative flex-grow-1 d-flex flex-column overflow-hidden">
     <div class="position-absolute top-0 start-50 translate-middle-x mt-3">
       <button id="addRod" class="btn btn-primary rounded-circle d-flex align-items-center justify-content-center" style="width:3rem;height:3rem;font-size:1.5rem;">+</button>
     </div>
     <div id="rodContainer" class="flex-grow-1 overflow-auto mt-5"></div>
   </div>
-  <footer class="p-2 border-top">
+  <footer class="p-2 border-top bg-white position-sticky bottom-0">
     <button id="closeSession" class="btn btn-danger w-100">Terminer la session</button>
   </footer>
 
   <div id="timerDialog" class="d-none position-fixed top-0 start-0 w-100 h-100 bg-dark bg-opacity-50 justify-content-center align-items-center">
     <div class="bg-white p-4 rounded">
-      <input type="number" id="timerMinutes" class="form-control mb-3 text-center" min="1" max="180" value="5" />
+      <label for="timerMinutes" class="form-label">Durée du timer</label>
+      <select id="timerMinutes" class="form-select mb-3 text-center"></select>
       <div class="text-end">
         <button id="timerCancel" class="btn btn-secondary me-2">Annuler</button>
         <button id="timerOk" class="btn btn-primary">OK</button>
       </div>
     </div>
   </div>
-  <script src="utils.js"></script>
-  <script src="main.js"></script>
+  <script src="utils.js?v=1"></script>
+  <script src="main.js?v=1"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Prevent browser caching with no-cache meta tags and cache-busting script URLs
- Keep session footer visible, add timer duration selector, and restyle controls for readability
- Reset and restart timer when recording fish catches

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bbeb4730e4832585cfcc500d5d2710