### PR TITLE
Refactor rod card layout and prevent page overflow

### DIFF
--- a/src/main/resources/static/forgot.html
+++ b/src/main/resources/static/forgot.html
@@ -9,7 +9,7 @@
   <meta http-equiv="Expires" content="0" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
 </head>
-<body class="d-flex justify-content-center align-items-center min-vh-100">
+<body class="d-flex justify-content-center align-items-center min-vh-100 overflow-hidden">
   <div class="container" style="max-width: 400px;">
     <div id="step1">
       <div class="mb-3">

--- a/src/main/resources/static/home.html
+++ b/src/main/resources/static/home.html
@@ -9,12 +9,12 @@
   <meta http-equiv="Expires" content="0" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
 </head>
-<body>
+<body class="d-flex flex-column min-vh-100 overflow-hidden">
   <header class="d-flex justify-content-between align-items-center p-2 border-bottom">
     <span id="usernameDisplay"></span>
     <button id="logoutBtn" class="btn btn-link">&#x23FB;</button>
   </header>
-  <div class="d-flex justify-content-center align-items-center min-vh-100">
+  <div class="flex-grow-1 d-flex justify-content-center align-items-center">
     <div class="container text-center" style="max-width: 400px;">
       <button id="startSession" class="btn btn-primary w-100">Démarrer une nouvelle session</button>
     </div>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -9,7 +9,7 @@
   <meta http-equiv="Expires" content="0" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
 </head>
-<body class="d-flex justify-content-center align-items-center min-vh-100">
+<body class="d-flex justify-content-center align-items-center min-vh-100 overflow-hidden">
   <div class="container" style="max-width: 400px;">
     <form id="loginForm">
       <div class="mb-3">

--- a/src/main/resources/static/main.js
+++ b/src/main/resources/static/main.js
@@ -150,8 +150,13 @@ document.addEventListener('DOMContentLoaded', async () => {
         const card = document.createElement('div');
         card.className = 'card m-3 p-3 d-flex align-items-center';
 
+        const timer = document.createElement('span');
+        timer.textContent = '00:00';
+        timer.style.fontFamily = 'DS-Digital';
+        timer.className = 'display-5 me-3';
+
         const counter = document.createElement('div');
-        counter.className = 'd-flex align-items-center bg-white rounded p-1';
+        counter.className = 'd-flex align-items-center bg-white rounded p-1 mx-auto';
 
         const minus = document.createElement('button');
         minus.className = 'btn btn-outline-secondary btn-sm';
@@ -169,13 +174,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         counter.appendChild(count);
         counter.appendChild(plus);
 
-        const timer = document.createElement('span');
-        timer.textContent = '00:00';
-        timer.style.fontFamily = 'DS-Digital';
-        timer.className = 'display-5 flex-grow-1 text-center';
-
         const del = document.createElement('button');
-        del.className = 'btn btn-outline-danger ms-2';
+        del.className = 'btn btn-danger ms-auto';
         del.textContent = '🗑️';
 
         del.addEventListener('click', async () => {
@@ -268,8 +268,8 @@ document.addEventListener('DOMContentLoaded', async () => {
           }
         });
 
-        card.appendChild(counter);
         card.appendChild(timer);
+        card.appendChild(counter);
         card.appendChild(del);
         rodContainer.appendChild(card);
       }

--- a/src/main/resources/static/register.html
+++ b/src/main/resources/static/register.html
@@ -9,7 +9,7 @@
   <meta http-equiv="Expires" content="0" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
 </head>
-<body class="d-flex justify-content-center align-items-center min-vh-100">
+<body class="d-flex justify-content-center align-items-center min-vh-100 overflow-hidden">
   <div class="container" style="max-width: 400px;">
     <form id="registerForm">
       <div class="mb-3">


### PR DESCRIPTION
## Summary
- Reorder rod card UI with timer on the left, centered counter, and red delete button
- Stop scrolling on login, registration, password reset, and home pages

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bbee2eeb248325a713ebed6372aa28