### PR TITLE
Fix rod card layout

### DIFF
--- a/src/main/resources/static/main.js
+++ b/src/main/resources/static/main.js
@@ -148,7 +148,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
       function createRodCard(rod) {
         const card = document.createElement('div');
-        card.className = 'card m-3 p-3 d-flex align-items-center gap-3 w-100';
+        card.className = 'card m-3 p-3 d-flex flex-row align-items-center gap-3 w-100';
 
         const timer = document.createElement('span');
         timer.textContent = '00:00';


### PR DESCRIPTION
## Summary
- align rod card elements horizontally by adding `flex-row`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf29dcb8483259f250ffc998dec75