### PR TITLE
Adjust session page layout

### DIFF
--- a/src/main/resources/static/main.js
+++ b/src/main/resources/static/main.js
@@ -148,7 +148,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
       function createRodCard(rod) {
         const card = document.createElement('div');
-        card.className = 'card m-3 p-3 d-flex flex-row align-items-center gap-3 w-100';
+        card.className = 'card m-3 p-3 d-flex flex-row align-items-center gap-3';
 
         const timer = document.createElement('span');
         timer.textContent = '00:00';

--- a/src/main/resources/static/session.html
+++ b/src/main/resources/static/session.html
@@ -20,15 +20,16 @@
   </style>
 </head>
 <body class="d-flex flex-column min-vh-100 overflow-hidden">
-  <header class="d-flex justify-content-between align-items-center p-2 border-bottom">
+  <header class="d-flex align-items-center p-2 border-bottom">
     <span id="usernameDisplay"></span>
+    <span class="flex-grow-1 text-center">Mes cannes</span>
     <button id="logoutBtn" class="btn btn-link">&#x23FB;</button>
   </header>
-  <div class="position-relative flex-grow-1 d-flex flex-column overflow-hidden">
-    <div class="position-absolute top-0 start-50 translate-middle-x mt-3">
+  <div class="flex-grow-1 overflow-auto d-flex flex-column">
+    <div id="rodContainer" class="flex-grow-1 p-3"></div>
+    <div class="text-center mb-3">
       <button id="addRod" class="btn btn-primary rounded-circle d-flex align-items-center justify-content-center" style="width:3rem;height:3rem;font-size:1.5rem;">+</button>
     </div>
-    <div id="rodContainer" class="flex-grow-1 overflow-auto mt-5"></div>
   </div>
   <footer class="p-2 border-top bg-white position-sticky bottom-0">
     <button id="closeSession" class="btn btn-danger w-100">Terminer la session</button>


### PR DESCRIPTION
## Summary
- Show "Mes cannes" title in session header
- Move add rod button below rod list and make content scrollable
- Fix rod card width overflow

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0a3e2a08832597ae379613518f05