### PR TITLE
feat: add timer sound and login logo

### DIFF
--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -11,6 +11,9 @@
 </head>
 <body class="d-flex justify-content-center align-items-center min-vh-100 overflow-hidden">
   <div class="container" style="max-width: 400px;">
+    <div class="text-center mb-3">
+      <img src="img/logo.png" alt="Logo" class="img-fluid" />
+    </div>
     <form id="loginForm">
       <div class="mb-3">
         <label for="login" class="form-label">Identifiant</label>

--- a/src/main/resources/static/main.js
+++ b/src/main/resources/static/main.js
@@ -1,5 +1,6 @@
 document.addEventListener('DOMContentLoaded', async () => {
   const sessionId = localStorage.getItem('sessionId');
+  const dingSound = new Audio('sound/ding.mp3');
 
   async function validateSession() {
     if (!sessionId) return false;
@@ -245,6 +246,8 @@ document.addEventListener('DOMContentLoaded', async () => {
               card.classList.remove('bg-success', 'blink');
               card.classList.add('border', 'border-danger');
               timer.classList.add('text-danger');
+              dingSound.currentTime = 0;
+              dingSound.play();
             }
           }, 1000);
         }


### PR DESCRIPTION
## Summary
- display logo above login form
- play a ding sound when a rod timer finishes

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3f6914788325931b314c14a59cc3