### PR TITLE
Allow naming fishing rods

### DIFF
--- a/src/main/kotlin/com/ggc/fishingcopilot/fishingsession/controller/FishingSessionController.kt
+++ b/src/main/kotlin/com/ggc/fishingcopilot/fishingsession/controller/FishingSessionController.kt
@@ -3,6 +3,7 @@ package com.ggc.fishingcopilot.fishingsession.controller
 import com.ggc.fishingcopilot.fishingsession.model.dto.CreateFishingSessionRequest
 import com.ggc.fishingcopilot.fishingsession.model.dto.FishingSessionResponse
 import com.ggc.fishingcopilot.fishingsession.rod.FishingRodService
+import com.ggc.fishingcopilot.fishingsession.rod.model.dto.CreateRodRequest
 import com.ggc.fishingcopilot.fishingsession.rod.model.dto.RodResponse
 import com.ggc.fishingcopilot.fishingsession.service.FishingSessionService
 import io.swagger.v3.oas.annotations.Operation
@@ -55,10 +56,11 @@ class FishingSessionController(
     @Operation(summary = "Add fishing rod", description = "Add a fishing rod to the session")
     fun addRod(
         @RequestHeader("sessionId") sessionId: UUID,
-        @PathVariable("sessionId") fishingSessionId: Int
+        @PathVariable("sessionId") fishingSessionId: Int,
+        @RequestBody req: CreateRodRequest
     ): ResponseEntity<RodResponse> {
-        val rod = rodService.addRod(sessionId, fishingSessionId)
-        return ResponseEntity.ok(RodResponse(rod.id, 0))
+        val rod = rodService.addRod(sessionId, fishingSessionId, req.name)
+        return ResponseEntity.ok(RodResponse(rod.id, rod.name, 0))
     }
 
     @DeleteMapping("/fishing-session/{sessionId}/rod/{rodId}")
@@ -79,8 +81,8 @@ class FishingSessionController(
         @PathVariable("sessionId") fishingSessionId: Int,
         @PathVariable rodId: Int
     ): ResponseEntity<RodResponse> {
-        val count = rodService.addFish(sessionId, fishingSessionId, rodId) ?: return ResponseEntity.notFound().build()
-        return ResponseEntity.ok(RodResponse(rodId, count))
+        val resp = rodService.addFish(sessionId, fishingSessionId, rodId) ?: return ResponseEntity.notFound().build()
+        return ResponseEntity.ok(resp)
     }
 
     @DeleteMapping("/fishing-session/{sessionId}/rod/{rodId}/fish")
@@ -90,7 +92,7 @@ class FishingSessionController(
         @PathVariable("sessionId") fishingSessionId: Int,
         @PathVariable rodId: Int
     ): ResponseEntity<RodResponse> {
-        val count = rodService.removeFish(sessionId, fishingSessionId, rodId) ?: return ResponseEntity.notFound().build()
-        return ResponseEntity.ok(RodResponse(rodId, count))
+        val resp = rodService.removeFish(sessionId, fishingSessionId, rodId) ?: return ResponseEntity.notFound().build()
+        return ResponseEntity.ok(resp)
     }
 }

--- a/src/main/kotlin/com/ggc/fishingcopilot/fishingsession/rod/model/dto/FishingRodDto.kt
+++ b/src/main/kotlin/com/ggc/fishingcopilot/fishingsession/rod/model/dto/FishingRodDto.kt
@@ -1,6 +1,11 @@
 package com.ggc.fishingcopilot.fishingsession.rod.model.dto
 
+data class CreateRodRequest(
+    val name: String
+)
+
 data class RodResponse(
     val id: Int,
+    val name: String,
     val fishCount: Int
 )

--- a/src/main/kotlin/com/ggc/fishingcopilot/fishingsession/rod/model/entity/FishingRod.kt
+++ b/src/main/kotlin/com/ggc/fishingcopilot/fishingsession/rod/model/entity/FishingRod.kt
@@ -1,6 +1,7 @@
 package com.ggc.fishingcopilot.fishingsession.rod.model.entity
 
 import com.ggc.fishingcopilot.fishingsession.model.entity.FishingSession
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
@@ -15,6 +16,9 @@ class FishingRod(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Int = 0,
+
+    @Column(length = 20, nullable = false)
+    var name: String,
 
     @ManyToOne
     @JoinColumn(name = "session_id", nullable = false)

--- a/src/main/resources/db/migration/V6__add_rod_name.sql
+++ b/src/main/resources/db/migration/V6__add_rod_name.sql
@@ -1,0 +1,2 @@
+ALTER TABLE fishing_rod
+    ADD COLUMN name VARCHAR(20) NOT NULL DEFAULT '';

--- a/src/main/resources/static/home.html
+++ b/src/main/resources/static/home.html
@@ -20,6 +20,6 @@
     </div>
   </div>
   <script src="utils.js?v=1"></script>
-  <script src="main.js?v=2"></script>
+  <script src="main.js?v=4"></script>
 </body>
 </html>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -31,6 +31,6 @@
     </div>
   </div>
   <script src="utils.js?v=1"></script>
-  <script src="main.js?v=2"></script>
+  <script src="main.js?v=4"></script>
 </body>
 </html>

--- a/src/main/resources/static/main.js
+++ b/src/main/resources/static/main.js
@@ -149,7 +149,15 @@ document.addEventListener('DOMContentLoaded', async () => {
 
       function createRodCard(rod) {
         const card = document.createElement('div');
-        card.className = 'card m-3 p-3 d-flex flex-row align-items-center gap-3';
+        card.className = 'card m-3 p-3 d-flex flex-column gap-3';
+
+        const nameEl = document.createElement('div');
+        nameEl.textContent = rod.name;
+        nameEl.className = 'fw-bold text-center fs-4';
+        card.appendChild(nameEl);
+
+        const row = document.createElement('div');
+        row.className = 'd-flex flex-row align-items-center gap-3';
 
         const timer = document.createElement('span');
         timer.textContent = '00:00';
@@ -271,9 +279,10 @@ document.addEventListener('DOMContentLoaded', async () => {
           }
         });
 
-        card.appendChild(timer);
-        card.appendChild(counter);
-        card.appendChild(del);
+        row.appendChild(timer);
+        row.appendChild(counter);
+        row.appendChild(del);
+        card.appendChild(row);
         rodContainer.insertBefore(card, addRodBtn.parentElement);
       }
       const rodsResp = await apiFetch(`/fishing-session/${current.id}/rods`, { headers: { sessionId } });
@@ -284,16 +293,20 @@ document.addEventListener('DOMContentLoaded', async () => {
 
       if (addRodBtn) {
         addRodBtn.addEventListener('click', async () => {
+          const count = rodContainer.querySelectorAll('.card').length;
+          let name = prompt('Nom de la canne', `canne #${count + 1}`) || `canne #${count + 1}`;
+          name = name.substring(0, 20);
           const resp = await apiFetch(`/fishing-session/${current.id}/rods`, {
             method: 'POST',
-            headers: { sessionId },
+            headers: { sessionId, 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name }),
           });
-        if (resp.ok) {
-          const data = await resp.json();
-          createRodCard(data);
-        }
-      });
-    }
+          if (resp.ok) {
+            const data = await resp.json();
+            createRodCard(data);
+          }
+        });
+      }
 
     closeBtn.addEventListener('click', async () => {
       await apiFetch('/fishing-session/close', {

--- a/src/main/resources/static/session.html
+++ b/src/main/resources/static/session.html
@@ -47,6 +47,6 @@
     </div>
   </div>
   <script src="utils.js?v=1"></script>
-  <script src="main.js?v=3"></script>
+  <script src="main.js?v=4"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow users to name rods when adding them and persist in database
- display rod names prominently on session cards

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68bc40637898832590dd4f22fcd1a234