### PR TITLE
Reduce login page logo size

### DIFF
--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -8,11 +8,16 @@
   <meta http-equiv="Pragma" content="no-cache" />
   <meta http-equiv="Expires" content="0" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <style>
+    .login-logo {
+      max-width: 150px;
+    }
+  </style>
 </head>
 <body class="d-flex justify-content-center align-items-center min-vh-100 overflow-hidden">
   <div class="container" style="max-width: 400px;">
     <div class="text-center mb-3">
-      <img src="img/logo.png" alt="Logo" class="img-fluid" />
+      <img src="img/logo.png" alt="Logo" class="img-fluid login-logo" />
     </div>
     <form id="loginForm">
       <div class="mb-3">


### PR DESCRIPTION
## Summary
- limit login logo width so forgot password link remains visible

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.example:demo: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4203015083258b257aaa581d943b