### PR TITLE
Fix rod list overflow by enabling scrolling

### DIFF
--- a/src/main/resources/static/session.html
+++ b/src/main/resources/static/session.html
@@ -25,7 +25,7 @@
     <span class="flex-grow-1 text-center">Mes cannes</span>
     <button id="logoutBtn" class="btn btn-link">&#x23FB;</button>
   </header>
-  <div class="flex-grow-1 overflow-auto">
+  <div class="flex-grow-1 overflow-auto" style="min-height: 0;">
     <div id="rodContainer" class="d-flex flex-column p-3">
       <div class="text-center mb-3">
         <button id="addRod" class="btn btn-primary rounded-circle d-flex align-items-center justify-content-center" style="width:3rem;height:3rem;font-size:1.5rem;">+</button>


### PR DESCRIPTION
## Summary
- Allow the rod list container to shrink and scroll so new rods never overflow off-screen

## Testing
- `mvn -q test` *(fails: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:3.5.5 (Network is unreachable))*

------
https://chatgpt.com/codex/tasks/task_e_68bc44136c7083258222408bbf9cbdac