### PR TITLE
Fix mobile audio playback and enable scrollable rod list

### DIFF
--- a/src/main/resources/static/home.html
+++ b/src/main/resources/static/home.html
@@ -21,6 +21,6 @@
     </div>
   </div>
   <script src="utils.js?v=1"></script>
-  <script src="main.js?v=4"></script>
+  <script src="main.js?v=5"></script>
 </body>
 </html>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -37,6 +37,6 @@
     </div>
   </div>
   <script src="utils.js?v=1"></script>
-  <script src="main.js?v=4"></script>
+  <script src="main.js?v=5"></script>
 </body>
 </html>

--- a/src/main/resources/static/main.js
+++ b/src/main/resources/static/main.js
@@ -1,6 +1,14 @@
 document.addEventListener('DOMContentLoaded', async () => {
   const sessionId = localStorage.getItem('sessionId');
   const dingSound = new Audio('sound/ding.mp3');
+  function unlockSound() {
+    dingSound.play().then(() => {
+      dingSound.pause();
+      dingSound.currentTime = 0;
+    }).catch(() => {});
+  }
+  document.addEventListener('click', unlockSound, { once: true });
+  document.addEventListener('touchstart', unlockSound, { once: true });
 
   async function validateSession() {
     if (!sessionId) return false;

--- a/src/main/resources/static/session.html
+++ b/src/main/resources/static/session.html
@@ -26,11 +26,9 @@
     <span class="flex-grow-1 text-center">Mes cannes</span>
     <button id="logoutBtn" class="btn btn-link">&#x23FB;</button>
   </header>
-  <div class="flex-grow-1 overflow-auto" style="min-height: 0;">
-    <div id="rodContainer" class="d-flex flex-column p-3">
-      <div class="text-center mb-3">
-        <button id="addRod" class="btn btn-primary rounded-circle d-flex align-items-center justify-content-center" style="width:3rem;height:3rem;font-size:1.5rem;">+</button>
-      </div>
+  <div id="rodContainer" class="flex-grow-1 d-flex flex-column p-3 overflow-auto" style="min-height:0;">
+    <div class="text-center mb-3">
+      <button id="addRod" class="btn btn-primary rounded-circle d-flex align-items-center justify-content-center" style="width:3rem;height:3rem;font-size:1.5rem;">+</button>
     </div>
   </div>
   <footer class="p-2 border-top bg-dark position-sticky bottom-0">
@@ -48,6 +46,6 @@
     </div>
   </div>
   <script src="utils.js?v=1"></script>
-  <script src="main.js?v=4"></script>
+  <script src="main.js?v=5"></script>
 </body>
 </html>

--- a/src/main/resources/static/styles.css
+++ b/src/main/resources/static/styles.css
@@ -6,3 +6,7 @@ body {
 a, a:hover {
   color: #0d6efd;
 }
+
+#rodContainer {
+  overflow-y: auto;
+}


### PR DESCRIPTION
## Summary
- Prime audio playback on first user interaction to allow sound on mobile
- Make rods section scrollable and adjust layout
- Bump static pages to load new script version

## Testing
- `mvn -q test` *(fails: Network is unreachable while resolving parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68bcbb47903483258b793a4cf8b40828